### PR TITLE
Fix Publish workflow: skip duplicate NuGet packages

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -106,6 +106,7 @@ Task("Publish-NuGet")
         {
             Source = "https://api.nuget.org/v3/index.json",
             ApiKey = apiKey,
+            SkipDuplicate = true,
         });
     }
 });


### PR DESCRIPTION
## Summary
- The Publish workflow has been failing since Feb 24 because `dotnet nuget push` returns a **409 Conflict** when version `1.1.0` already exists on NuGet.org
- Added `SkipDuplicate = true` to `DotNetNuGetPushSettings` in `build.cake` so already-published versions are silently skipped instead of failing the build

## Test plan
- [ ] Verify the Publish workflow passes on this branch
- [ ] Confirm that new package versions are still published correctly