### PR TITLE
fix: replace CodeQL autobuild with manual C# build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ dev, main ]
+  pull_request:
+    branches: [ dev, main ]
+  schedule:
+    - cron: '17 6 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: csharp
+            build-mode: manual
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Setup .NET SDK
+        if: matrix.language == 'csharp'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            10.0.x
+
+      - name: Build
+        if: matrix.language == 'csharp'
+        run: dotnet build --no-incremental
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

- The CodeQL default setup's autobuild was failing for C# with: *"We were unable to automatically build your code"*
- Disabled the CodeQL default setup and replaced it with an advanced workflow file (`.github/workflows/codeql.yml`)
- Uses `build-mode: manual` for C# with an explicit `dotnet build --no-incremental` step
- Uses `build-mode: none` for `actions` language analysis (unchanged behavior)

## Test plan

- [ ] Verify the CodeQL workflow triggers on this PR and both `actions` and `csharp` jobs pass
- [ ] Confirm the C# analysis completes without autobuild errors