### PR TITLE
ci: publish to NuGet via Trusted Publishing, not a long-lived key

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,11 @@ jobs:
         name: Publish NuGet Packages
         if: "!contains(github.event.head_commit.message, 'skip-ci') || startsWith(github.ref, 'refs/tags/')"
         runs-on: ubuntu-latest
+        # Minimal on purpose: build.cake's Publish-NuGet target only pushes to nuget.org, so nothing
+        # here needs write access to the repository. id-token is what Trusted Publishing exchanges.
+        permissions:
+            contents: read
+            id-token: write # request the GitHub OIDC token for NuGet Trusted Publishing
         steps:
             - name: Checkout
               uses: actions/checkout@v6
@@ -34,10 +39,23 @@ jobs:
                   dotnet-version: |
                       10.0.x
 
+            # Trusted Publishing: exchanges the OIDC token for a NuGet key valid ~1 hour, so no
+            # long-lived secret is stored. Cake neither knows nor cares that the key is short-lived
+            # — it just receives one through --nuget-key. Keep this adjacent to the publish step
+            # below so the key cannot expire in between.
+            # Requires a Trusted Publishing policy on nuget.org for MasterCommander naming this
+            # repository and publish.yml, plus the NUGET_USER secret (the nuget.org profile name).
+            - name: NuGet login (OIDC -> short-lived key)
+              id: nuget-login
+              uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+              with:
+                  user: ${{ secrets.NUGET_USER }}
+
+            # --github-key is dropped: build.cake reads only `nuget-key`, so it was a dead argument
+            # handing GITHUB_TOKEN to a script that never asked for it.
             - name: Publish
               shell: bash
               run: |
                   dotnet tool restore
                   dotnet cake --target="publish" \
-                    --nuget-key="${{secrets.NUGET_API_KEY}}" \
-                    --github-key="${{secrets.GITHUB_TOKEN}}"
+                    --nuget-key="${{ steps.nuget-login.outputs.NUGET_API_KEY }}"


### PR DESCRIPTION
The publish job handed a long-lived `NUGET_API_KEY` to cake. It now uses **Trusted Publishing**: the GitHub OIDC token is exchanged for a NuGet key valid ~1 hour and that is passed through `--nuget-key` instead. The only remaining secret is `NUGET_USER` — the nuget.org profile name, not a credential.

**`build.cake` is unchanged.** Cake neither knows nor cares that the key is short-lived; it just receives one. That is what makes this migration cheap for tool-driven builds.

### Two findings while reading the publish path

**`--github-key` was dead.** `build.cake` reads only `nuget-key` — `--github-key=${{ secrets.GITHUB_TOKEN }}` was handing a token to a script that never asked for it. Dropped in this change.

**The job had no `permissions` block at all**, so it ran on repository defaults. It now declares the minimum: `contents: read` + `id-token: write`. I checked `Publish-NuGet` before narrowing it — it only pushes to nuget.org, so nothing needs write access. (Its inline comment says "Publish to GitHub Packages" but the source is `api.nuget.org`; stale comment, left alone as out of scope.)

### Required before the next release

1. Register a Trusted Publishing policy on nuget.org for `MasterCommander`, naming `phmatray/MasterCommander` and `publish.yml`.
2. Set the `NUGET_USER` secret.
3. Cut one release, confirm the package appears, **then** delete `NUGET_API_KEY`.